### PR TITLE
Feature/QBIOSSDK-426 and 424

### DIFF
--- a/sample-chat/sample-chat/ViewController/ChatViewController.m
+++ b/sample-chat/sample-chat/ViewController/ChatViewController.m
@@ -170,8 +170,19 @@ UIActionSheetDelegate
     // Saving currently opened dialog.
     [ServicesManager instance].currentDialogID = self.dialog.ID;
     
-    if ([self.items count] == 0) {
+    if ([self.items count] > 0) {
+        [self refreshMessagesShowingProgress:NO];
+    }
+    else {
         [self refreshMessagesShowingProgress:YES];
+    }
+    
+    // joining group dialog if needed
+    if (self.dialog.type != QBChatDialogTypePrivate && [QBChat instance].isLoggedIn) {
+        [[ServicesManager instance].chatService joinToGroupDialog:self.dialog failed:^(NSError *error) {
+            //
+            NSLog(@"Failed to join group dialog with error: %@", error.localizedDescription);
+        }];
     }
 }
 
@@ -685,6 +696,10 @@ UIActionSheetDelegate
 
 - (void)chatServiceChatDidLogin
 {
+    if (self.dialog.type != QBChatDialogTypePrivate) {
+        [self refreshMessagesShowingProgress:NO];
+    }
+    
     [SVProgressHUD showSuccessWithStatus:@"Logged in!"];
     
     for (QBChatMessage* message in self.unreadMessages) {

--- a/sample-chat/sample-chat/ViewController/ChatViewController.m
+++ b/sample-chat/sample-chat/ViewController/ChatViewController.m
@@ -698,6 +698,20 @@ UIActionSheetDelegate
 {
     if (self.dialog.type != QBChatDialogTypePrivate) {
         [self refreshMessagesShowingProgress:NO];
+        
+        // in order to join/rejoin group dialog it must be up to date with the server one
+        [[ServicesManager instance].chatService loadDialogWithID:self.dialog.ID completion:^(QBChatDialog *loadedDialog) {
+            //
+            if (loadedDialog != nil) {
+                [[ServicesManager instance].chatService joinToGroupDialog:loadedDialog failed:^(NSError *error) {
+                    NSLog(@"Failed to join room with error: %@", error.localizedDescription);
+                }];
+            }
+            else {
+                // dialog was not found, let dialogcontroller handle it
+                [self.navigationController popViewControllerAnimated:NO];
+            }
+        }];
     }
     
     [SVProgressHUD showSuccessWithStatus:@"Logged in!"];


### PR DESCRIPTION
Messages now getting READ status in a correct way.
Fixed group dialog rejoin if ChatViewController was opened not from DialogsController. The issue with group dialog rejoin was associated with message READ status issue.