### PR TITLE
Support ios 13

### DIFF
--- a/Framework/Quickblox.framework/Headers/Quickblox.h
+++ b/Framework/Quickblox.framework/Headers/Quickblox.h
@@ -59,5 +59,5 @@
 #import "QBUpdateUserParameters.h"
 #import "QBUUser.h"
 
-/// Framework version 2.17.2
+/// Framework version 2.17.3
 FOUNDATION_EXPORT NSString * const QuickbloxFrameworkVersion;


### PR DESCRIPTION
For iOS SDKs up to version 2.17.2 (2.17.3) Xcode 10 or lower should be used. Because if you build your App with Xcode 11, users with iOS 13 will stop receiving incoming calls.

Currently we are adding support for Xcode 11 and iOS 13 in an upcoming version of the SDK.